### PR TITLE
Add utf-8 meta tag to layout

### DIFF
--- a/app/views/layout.pug
+++ b/app/views/layout.pug
@@ -2,6 +2,7 @@ doctype html
 html
   head
     title= title
+    meta(charset="utf-8")
     link(rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous")
     link(rel="stylesheet" href="/css/timetable_styles.css")
 

--- a/views/timetable/layout.pug
+++ b/views/timetable/layout.pug
@@ -2,6 +2,7 @@ doctype html
 html
   head
     title= title
+    meta(charset="utf-8")
     link(rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous")
     link(rel="stylesheet" href=`${config.assetPath}css/timetable_styles.css`)
     meta(name="viewport" content="initial-scale=1.0, width=device-width")


### PR DESCRIPTION
This will support the display of unescaped entities in the generated HTML (like the &mdash that is the default `noServiceSymbol` in config-sample.json).