### PR TITLE
add process.exit in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ If you are using this as a node module as part of an application, you can includ
     gtfsToHTML(config)
     .then(() => {
       console.log('HTML Generation Successful');
+      process.exit();
     })
     .catch(err => {
       console.error(err);
+      process.exit(1);
     });
 
 ## Configuration


### PR DESCRIPTION
You don't want your process to just hang on completion... also makes it consistent with the cli example.