### PR TITLE
Docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:16
+FROM node:14
 
 RUN apt update
 RUN apt install -y chromium

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+# Docker area 🐳
+
+Use the files contained in this folder to run GTFS-to-HTML with `docker` (or `docker-compose`).
+
+Read more into the documentation.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  gtfs-to-html:
+    image: gtfs-to-html
+    build:
+      context: .
+    volumes:
+      - ./html:/html
+      - ./config.json:/config.json

--- a/www/docs/quick-start.md
+++ b/www/docs/quick-start.md
@@ -38,9 +38,13 @@ By default, node has a memory limit of 512 MB or 1 GB. If you have a very large 
 
 ## Docker Usage
 
-A `Dockerfile` is available in the `docker` directory. You can use [docker](https://docker.com) to run GTFS-to-HTML.
+You can use both [`docker`](https://docker.com) and [`docker-compose`](https://docs.docker.com/compose/) to run GTFS-to-HTML.
 
-* Create a config.json file and save in the same directory as your `Dockerfile`. You can use `config-sample.json` from the project root as a starting point.
+### Dockerfile
+
+A `Dockerfile` is available in the `docker` directory.
+
+* Create a `config.json` file and save in the same directory as your `Dockerfile`. You can use `config-sample.json` from the project root as a starting point.
 
 * Build the docker image:
 
@@ -60,6 +64,21 @@ A `Dockerfile` is available in the `docker` directory. You can use [docker](http
 
         // For example:
         docker cp ca45a38963d9:/html .
+
+### Docker Compose
+
+Docker compose is used for multi-container Docker applications. In this context, it is just a convenient way to manage volumes. This allows (_i_) to get the generated HTML out of the docker container without explicitly copying with `docker cp`, and (_ii_) to tweak and run a new configuration without rebuilding the container from scratch.
+
+* Create a `config.json` file and save in the same directory as your `Dockerfile` and `docker-compose.yml`;
+
+* build and run the container:
+
+        docker-compose up
+
+* the generated HTML will be available in the folder `html` next to docker files.
+
+Do you want to change something? Just delete the old HTML, change your `config.json`, and finally run `docker-compose up` again.
+
 
 ## Usage as a node module
 


### PR DESCRIPTION
Hello there. This PR just adds a shorthand for the Docker-based case with docker-compose.

Reasons behind this PR:
* you can now run just a unique command (`docker-compose up`)
* HTML is spat out automatically
* You can tweak `config.json` and relaunch the container without rebuilding

Please, note that this approach is backward compatible with the legacy `Dockerfile`

The Dockerfile uses `node:14` (LTS) since `node:16` returned an error during the installation.

(See also #118)
